### PR TITLE
[WIP] Documentation improvements

### DIFF
--- a/src/CaosDB.jl
+++ b/src/CaosDB.jl
@@ -1,18 +1,25 @@
-#!/bin/env julia
-# Draft of the julia library for CaosDB
-# A. Schlemmer, 04/2019
-
+"""
+    CaosDB
+CaosDB interface for Julia.
+"""
 module CaosDB
 
 import HTTP.URIs: escapeuri
 import EzXML: ElementNode, TextNode, XMLDocument, link!
 
-# Type for managing the connection
-# --------------------------------
-# baseurl: The base url of your server. Example: "https://localhost:8887/playground/"
-# cacert: The path to a certificate pem file. If left empty no custom certificate will be used.
-# cookiestring: The cookiestring which will be set by the login function after logging in to caosdb.
-# verbose: When set to true the underlying curl library will respond more verbosively. Can be used for debugging.
+"""
+    Connection
+Type for managing the connection. Fields:
+
+- baseurl: The base url of your server.
+  Example: "https://localhost:8887/playground/"
+- cacert: The path to a certificate pem file.
+  If left empty no custom certificate will be used.
+- cookiestring: The cookiestring which will be set by the login function
+  after logging in to caosdb.
+- verbose: When set to `true` the underlying curl library will respond more
+  verbosively. Can be used for debugging.
+"""
 mutable struct Connection
     baseurl::Union{Missing,String}
     cacert::Union{Missing,String}
@@ -119,7 +126,7 @@ function entity_to_xml(entity::Entity)
     Converts an entity representation to XML.
     This is needed for passing the XML in the body of the HTTP request to the server.
     """
-    
+
     node = ElementNode(entity.role)
     sub_to_node(entity.parents, "Parents", node)
     sub_to_node(entity.properties, "Properties", node)
@@ -138,10 +145,10 @@ function entity_to_xml(entity::Entity)
         else
             node["datatype"] = entity.datatype
         end
-        
+
     end
-    
-    
+
+
     return(node)
 end
 
@@ -168,7 +175,7 @@ function _base_login(username, password, baseurl, cacert, verbose)
         error(response[7:end])
     end
     return response
-end    
+end
 
 # TODO: turn the underscore functions into error checking functions like seen above
 #       using a macro.

--- a/src/CaosDB.jl
+++ b/src/CaosDB.jl
@@ -64,29 +64,29 @@ function next_id()
 end
 
 Entity(role; id=next_id(), name=missing, value=missing,
-           parents=Vector{Entity}(), properties=Vector{Entity}(), datatype=missing,
-           unit=missing, description=missing) = Entity(role, id, name, value,
-                                                           parents, properties, datatype, unit,
-                                                           description)
+       parents=Vector{Entity}(), properties=Vector{Entity}(), datatype=missing,
+       unit=missing, description=missing) =
+Entity(role, id, name, value, parents, properties, datatype, unit, description)
 
 Property(;id=next_id(), name=missing, value=missing, parents=Vector{Entity}(),
-                           datatype=missing,
-                           unit=missing) = Entity("Property"; id=id, name=name, value=value, parents=parents,
-                      properties=Vector{Entity}(), datatype=datatype, unit=unit)
+         datatype=missing, unit=missing) =
+Entity("Property"; id=id, name=name, value=value, parents=parents,
+       properties=Vector{Entity}(), datatype=datatype, unit=unit)
 
 Record(;id=next_id(), name=missing, parents=Vector{Entity}(),
-           properties=Vector{Entity}()) = Entity("Record"; id=id, name=name, parents=parents, properties=properties)
+       properties=Vector{Entity}()) =
+Entity("Record"; id=id, name=name, parents=parents, properties=properties)
 
 RecordType(;id=next_id(), name=missing, parents=Vector{Entity}(), properties=Vector{Entity}()) = Entity("RecordType"; id=id, name=name, parents=parents, properties=properties)
 
-function sub_to_node(subs::Vector{Entity}, name::String, node)
-    """
-    Helper function
-    Checks whether the list subs has length greater 0.
-    Afterwards creates a new node with given name,
-    creates subnodes for each element of subs,
-    finally links the new node to node.
-    """
+"""
+    sub2node(subs::Vector{Entity}, name::String, node)
+Check whether `subs` has length greater 0.
+Afterwards create a new node with given `name`,
+create subnodes for each element of `subs`,
+finally link the new node to `node`.
+"""
+function sub2node(subs::Vector{Entity}, name::String, node)
     if (length(subs) > 0)
         parentnode = ElementNode(name)
         for par in subs
@@ -97,11 +97,12 @@ function sub_to_node(subs::Vector{Entity}, name::String, node)
     end
 end
 
+"""
+    @addnonmissingattribute node entity entfield
+Add an attribute to an xml node if it is not missing in the entity.
+"""
 macro addnonmissingattribute(node, entity, entfield)
-    """
-    Add an attribute to an xml node if it is not missing
-    in the entity.
-    """
+
     t = esc(Symbol(entity))
     s = Symbol(entfield)
     n = esc(Symbol(node))
@@ -127,8 +128,8 @@ request to the server.
 function entity2xml(entity::Entity)
 
     node = ElementNode(entity.role)
-    sub_to_node(entity.parents, "Parents", node)
-    sub_to_node(entity.properties, "Properties", node)
+    sub2node(entity.parents, "Parents", node)
+    sub2node(entity.properties, "Properties", node)
     @addnonmissingattribute("node", "entity", "name")
     @addnonmissingattribute("node", "entity", "id")
     @addnonmissingattribute("node", "entity", "unit")
@@ -259,15 +260,15 @@ end
 
 # TODO: <Insert>*</Insert> missing
 
-entity_to_querystring(cont::Vector{Entity}) = join([element.name for element in cont], ',')
+entity2querystring(cont::Vector{Entity}) = join([element.name for element in cont], ',')
 
 insert(cont::Vector{Entity}, connection) = post("Entity/", xml2str(entity2xml(cont)), connection)
 update(cont::Vector{Entity}, connection) = put("Entity/", xml2str(entity2xml(cont)), connection)
 retrieve(querystring::String, connection::Connection) = xml2entity(get("Entity/" * querystring, connection))
 delete(querystring::String, connection::Connection) = _delete("Entity/" * querystring, connection)
 
-retrieve(cont::Vector{Entity}, connection) = retrieve(entity_to_querystring(cont), connection)
-delete(cont::Vector{Entity}, connection) = delete(entity_to_querystring(cont), connection)
+retrieve(cont::Vector{Entity}, connection) = retrieve(entity2querystring(cont), connection)
+delete(cont::Vector{Entity}, connection) = delete(entity2querystring(cont), connection)
 
 
 end

--- a/src/CaosDB.jl
+++ b/src/CaosDB.jl
@@ -90,7 +90,7 @@ function sub_to_node(subs::Vector{Entity}, name::String, node)
     if (length(subs) > 0)
         parentnode = ElementNode(name)
         for par in subs
-            subnode = entity_to_xml(par)
+            subnode = entity2xml(par)
             link!(parentnode, subnode)
         end
         link!(node, parentnode)
@@ -112,20 +112,19 @@ macro addnonmissingattribute(node, entity, entfield)
     end
 end
 
-function xml2str(xml)
-    """
-    Convert an xml node or document to a string.
-    """
-    return sprint(print, xml)
-end
+"""
+    xml2str(xml)
+Convert an xml node or document to a string.
+"""
+xml2str(xml) = sprint(print, xml)
 
-entities_to_xml(entities::Vector{Entity}) = [entity_to_xml(entity) for entity in entities]
-
-function entity_to_xml(entity::Entity)
-    """
-    Converts an entity representation to XML.
-    This is needed for passing the XML in the body of the HTTP request to the server.
-    """
+"""
+    entity2xlm(entity)
+Convert an `Entity` instance to XML.
+This is needed for passing the XML in the body of the HTTP
+request to the server.
+"""
+function entity2xml(entity::Entity)
 
     node = ElementNode(entity.role)
     sub_to_node(entity.parents, "Parents", node)
@@ -145,14 +144,13 @@ function entity_to_xml(entity::Entity)
         else
             node["datatype"] = entity.datatype
         end
-
     end
-
 
     return(node)
 end
 
-function xml_to_entity(xml)
+function xml2entity(xml)
+    error("not implemented yet")
     doc = parse_xml(xml)
     # ... process xml and create a container
 end
@@ -255,7 +253,7 @@ end
 
 
 function query(querystring, connection::Connection)
-    return xml_to_entity(get("Entity/?query=" *
+    return xml2entity(get("Entity/?query=" *
                              escapeuri(querystring), connection))
 end
 
@@ -263,9 +261,9 @@ end
 
 entity_to_querystring(cont::Vector{Entity}) = join([element.name for element in cont], ',')
 
-insert(cont::Vector{Entity}, connection) = post("Entity/", xml2str(entity_to_xml(cont)), connection)
-update(cont::Vector{Entity}, connection) = put("Entity/", xml2str(entity_to_xml(cont)), connection)
-retrieve(querystring::String, connection::Connection) = xml_to_entity(get("Entity/" * querystring, connection))
+insert(cont::Vector{Entity}, connection) = post("Entity/", xml2str(entity2xml(cont)), connection)
+update(cont::Vector{Entity}, connection) = put("Entity/", xml2str(entity2xml(cont)), connection)
+retrieve(querystring::String, connection::Connection) = xml2entity(get("Entity/" * querystring, connection))
 delete(querystring::String, connection::Connection) = _delete("Entity/" * querystring, connection)
 
 retrieve(cont::Vector{Entity}, connection) = retrieve(entity_to_querystring(cont), connection)


### PR DESCRIPTION
This PR brings some documentation-related improvements:

- Transforms comments into docstrings: comments can be only read by looking at the source code, docstrings can be accessed also within a Julia session.
- restricted chars per line to less than 92
- Moved documentation strings from within functions (Python syntax, invalid in Julia) to before function
- Added function call signature to docstrings. This is necessary in Julia, as due to Multiple Dispatch there is no way to deduce the "correct" call signature (there is no correct)
- Added a very simple "getting started" guide in the README (`@Alex`)
- Alings the documentation strings more with the Julia style guide: second person (do this) instead of third (does this)
- Unifies the `_to_` and `2` syntax (like `string2xml`): now everything uses `2`